### PR TITLE
CI with github actions to rebuild

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,26 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+    - name: go packages install
+      run: wget  https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz ; sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz ;
+    - name: Build Octant
+      run:  export PATH=$PATH:/usr/local/go/bin ; export GOBIN=$PWD/bin ; make
+    - name: copy
+      run: mkdir -p website/ ; cp bin/* website/
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+          branch: linux # The branch the action should deploy to.
+          folder: website/ # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch 
+          single-commit: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
     - name: go packages install
-      run: wget  https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz ; sudo rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz ;
+      run: wget  --progress=dot:mega  https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz ; sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.20.3.linux-amd64.tar.gz ;
     - name: Build Octant
       run:  export PATH=$PATH:/usr/local/go/bin ; export GOBIN=$PWD/bin ; make
     - name: copy


### PR DESCRIPTION
Contributes a CI script that builds the binaries using an ubuntu 20 (for older glibc), and distributes them from "linux" branch.

Installs and uses latest go version.

Binary works for me on cluster (but is not a full static link, hence I use ubuntu 20 for better portability on older systems).

After accepting PR, we should : 
* point in readme that binaries exist in "linux" branch of the repo for easy download
* in "Setting"->"Actions", we need to activate workflows and also allow read/write permissions so the upload can happen.


